### PR TITLE
Remove "Crash Bandicoot Japan"

### DIFF
--- a/RepackList.json
+++ b/RepackList.json
@@ -3312,22 +3312,6 @@
     "Info": "http://redump.org/disc/44574"
   },
   {
-    "Title ID": "4B4E0011",
-    "Title Name": "Crash Bandicoot Japan",
-    "Version": "00000001",
-    "Region": "JPN",
-    "Letter": "C",
-    "XBE Title": "Crash Bandicoot 4 - Sakuretsu! M.P (JPN)",
-    "Folder Name": "Crash Bandicoot 4 - Sakuretsu! M.P (JPN)",
-    "ISO Name": "Crash Bandicoot 4 - S.M.P (JPN)",
-    "ISO Checksum": "F8E52605",
-    "Process": "Y",
-    "Scrub": "Y",
-    "Category": "Game",
-    "Link": "aHR0cHM6Ly9hcmNoaXZlLm9yZy9kb3dubG9hZC9taWNyb3NvZnRfeGJveF9jX3BhcnQyL0NyYXNoJTIwQmFuZGljb290JTIwNCUyMC0lMjBTYWt1cmV0c3UlMjElMjBNYWppbiUyMFBvd2VyJTIwJTI4SmFwYW4lMjkuemlw",
-    "Info": "http://redump.org/disc/34119"
-  },
-  {
     "Title ID": "5655001F",
     "Title Name": "Crash Nitro Kart",
     "Version": "00000001",


### PR DESCRIPTION
"Crash Bandicoot Japan" is the same game as "Crash Bandicoot: tWoC".