### PR TITLE
Remove Puyo Pop Fever JPN

### DIFF
--- a/RepackList.json
+++ b/RepackList.json
@@ -15,21 +15,6 @@
     "Info": "http://redump.org/disc/49754"
   },
   {
-    "Title ID": "53450027",
-    "Title Name": "Puyo Pop Fever",
-    "Version": "00000001",
-    "Region": "JPN",
-    "Letter": "P",
-    "XBE Title": "Puyo Pop Fever (JPN)",
-    "Folder Name": "Puyo Pop Fever (JPN)",
-    "ISO Name": "Puyo Pop Fever (JPN)",
-    "ISO Checksum": "879C02FA",
-    "Process": "Y",
-    "Scrub": "Y",
-    "Category": "Game",
-    "Info": "http://redump.org/disc/33865"
-  },
-  {
     "Title ID": "4B4E001D",
     "Title Name": "Dancing Stage Unleashed",
     "Version": "00000001",


### PR DESCRIPTION
This game appears in the RepackList twice with the same title IDs.

What is the reason for including both? If there is no reason then only one of PAL or JPN should remain.