### PR TITLE
add an unpack folder option to improve performance

### DIFF
--- a/Repackinator/Actions/Repacker.cs
+++ b/Repackinator/Actions/Repacker.cs
@@ -43,7 +43,7 @@ namespace Repackinator.Actions
             File.AppendAllText("RepackLog.txt", logMessage.ToLogFormat());
         }
 
-        private int ProcessFile(string inputFile, string outputPath, GroupingEnum grouping, bool hasAllCrcs, bool upperCase, CompressEnum compressType, bool trimmedScrub, bool noSplit, CancellationToken cancellationToken)
+        private int ProcessFile(string inputFile, string outputPath, string unpackPath, GroupingEnum grouping, bool hasAllCrcs, bool upperCase, CompressEnum compressType, bool trimmedScrub, bool noSplit, CancellationToken cancellationToken)
         {
             try
             {
@@ -61,7 +61,7 @@ namespace Repackinator.Actions
                     return ProcessIso(inputFile, outputPath, grouping, upperCase, compressType, trimmedScrub, noSplit, cancellationToken);
                 }
 
-                return ProcessArchive(inputFile, outputPath, grouping, hasAllCrcs, upperCase, compressType, trimmedScrub, noSplit, cancellationToken);
+                return ProcessArchive(inputFile, outputPath, unpackPath, grouping, hasAllCrcs, upperCase, compressType, trimmedScrub, noSplit, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -70,7 +70,7 @@ namespace Repackinator.Actions
             }
         }
 
-        public int ProcessArchive(string inputFile, string outputPath, GroupingEnum grouping, bool hasAllCrcs, bool upperCase, CompressEnum compressType, bool trimmedScrub, bool noSplit, CancellationToken cancellationToken)
+        public int ProcessArchive(string inputFile, string outputPath, string tempPath, GroupingEnum grouping, bool hasAllCrcs, bool upperCase, CompressEnum compressType, bool trimmedScrub, bool noSplit, CancellationToken cancellationToken)
         {
             if (GameDataList == null)
             {
@@ -78,7 +78,9 @@ namespace Repackinator.Actions
                 return -1;
             }
 
+
             var unpackPath = Path.Combine(outputPath, "Repackinator-Temp");
+            if (!string.IsNullOrEmpty(tempPath)) unpackPath = Path.Combine(tempPath, "Repackinator-Temp");
             var processOutput = string.Empty;
             var deleteProcessOutput = false;
 
@@ -916,7 +918,7 @@ namespace Repackinator.Actions
                                     continue;
                                 }
 
-                                var gameIndex = ProcessFile(tempPath, config.OutputPath, config.Grouping, crcMissingCount == 0, config.UpperCase, config.CompressType, config.TrimmedScrub, config.NoSplit, cancellationToken);
+                                var gameIndex = ProcessFile(tempPath, config.OutputPath, config.UnpackPath, config.Grouping, crcMissingCount == 0, config.UpperCase, config.CompressType, config.TrimmedScrub, config.NoSplit, cancellationToken);
                                 if (gameIndex >= 0)
                                 {
                                     gameData[gameIndex].Process = "N";
@@ -976,7 +978,7 @@ namespace Repackinator.Actions
                         CurrentProgress.Progress1Text = $"Processing {i + 1} of {files.Count}";
                         SendProgress();
 
-                        var gameIndex = ProcessFile(file, config.OutputPath, config.Grouping, crcMissingCount == 0, config.UpperCase, config.CompressType, config.TrimmedScrub, config.NoSplit, cancellationToken);
+                        var gameIndex = ProcessFile(file, config.OutputPath, config.UnpackPath, config.Grouping, crcMissingCount == 0, config.UpperCase, config.CompressType, config.TrimmedScrub, config.NoSplit, cancellationToken);
                         if (gameIndex >= 0)
                         {
                             gameData[gameIndex].Process = "N";

--- a/Repackinator/Models/Config.cs
+++ b/Repackinator/Models/Config.cs
@@ -28,6 +28,8 @@ namespace Repackinator.Models
 
         public string OutputPath { get; set; }
 
+        public string UnpackPath { get; set; }
+
         public GroupingEnum Grouping { get; set; }
 
         public bool RecurseInput { get; set; }
@@ -54,6 +56,7 @@ namespace Repackinator.Models
             List = "Main";
             InputPath = string.Empty;
             OutputPath = string.Empty;
+            UnpackPath = string.Empty;
             Grouping = GroupingEnum.None;
             RecurseInput = false;
             UpperCase = false;

--- a/Repackinator/UI/ApplicationUI.cs
+++ b/Repackinator/UI/ApplicationUI.cs
@@ -17,6 +17,7 @@ namespace Repackinator.UI
         private GameData[]? m_gameDataList;
         private PathPicker? m_inputFolderPicker;
         private PathPicker? m_outputFolderPicker;
+        private PathPicker? m_unpackFolderPicker;
         private PathPicker? m_exportFolderPicker;
         private EditDialog? m_editDialog;
         private OkDialog? m_okDialog;
@@ -295,6 +296,10 @@ namespace Repackinator.UI
                 Mode = PathPicker.PickerMode.Folder
             };
 
+            m_unpackFolderPicker = new PathPicker {
+                Mode = PathPicker.PickerMode.Folder
+            };
+
             m_exportFolderPicker = new PathPicker
             {
                 Mode = PathPicker.PickerMode.Folder,
@@ -327,6 +332,7 @@ namespace Repackinator.UI
         {
             if (m_inputFolderPicker == null ||
                 m_outputFolderPicker == null ||
+                m_unpackFolderPicker == null ||
                 m_exportFolderPicker == null ||
                 m_editDialog == null ||
                 m_okDialog == null ||
@@ -349,6 +355,11 @@ namespace Repackinator.UI
             if (m_outputFolderPicker.Render() && !m_outputFolderPicker.Cancelled)
             {
                 m_config.OutputPath = m_outputFolderPicker.SelectedFolder;
+                Config.SaveConfig(m_config);
+            }
+
+            if (m_unpackFolderPicker.Render() && !m_unpackFolderPicker.Cancelled) {
+                m_config.UnpackPath = m_unpackFolderPicker.SelectedFolder;
                 Config.SaveConfig(m_config);
             }
 
@@ -886,6 +897,23 @@ namespace Repackinator.UI
             if (ImGui.Button("...##outputPicker", new Vector2(30, 21)))
             {
                 m_outputFolderPicker.ShowModal(Directory.GetCurrentDirectory());
+            }
+
+            ImGui.Spacing();
+
+            ImGui.Text("Unpack Folder:");
+            ImGui.SameLine();
+            ImGui.SetCursorPosX(150);
+            ImGui.PushItemWidth(400);
+            string unpackPath = m_config.UnpackPath;
+            if (ImGui.InputText("##unpackFolder", ref unpackPath, 260)) {
+                m_config.UnpackPath = unpackPath;
+                Config.SaveConfig(m_config);
+            }
+            ImGui.PopItemWidth();
+            ImGui.SameLine();
+            if (ImGui.Button("...##unpackPicker", new Vector2(30, 21))) {
+                m_unpackFolderPicker.ShowModal(Directory.GetCurrentDirectory());
             }
 
             ImGui.EndChild();


### PR DESCRIPTION
allows the temporary iso extraction from zip files to go to a different drive (ideally a ram disk), which can significantly improve performance

on a simple redump iso extraction from zip, trim scrub and write to uncompressed xbox iso, using the temp unpack folder on a ram disk reduced time taken by nearly 20% compared to pure ssd (saving against a hdd is likely to be much higher because of all the seeking back and forwards between the reads and writes if both are on the same disk)

using a ram disk is best for performance, but also saves wear on ssd with potentially hundreds of gb of writes for temporary intermediate files
